### PR TITLE
 feat: Add support for Public Bucket Domains

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,8 @@ interface Env {
 	AUTH_KEY: string;
 	R2_BUCKET: R2Bucket;
 	CACHE_CONTROL?: string;
+	CUSTOM_PUBLIC_BUCKET_DOMAIN?: string
+	ONLY_ALLOW_ACCESS_TO_PUBLIC_BUCKET?: boolean;
 }
 
 const router = Router();
@@ -91,6 +93,10 @@ router.post("/upload", authMiddleware, async (request: Request, env: Env): Promi
 	const returnUrl = new URL(request.url);
 	returnUrl.searchParams.delete('filename');
 	returnUrl.pathname = `/file/${filename}`;
+	if(env.CUSTOM_PUBLIC_BUCKET_DOMAIN){
+		returnUrl.host = env.CUSTOM_PUBLIC_BUCKET_DOMAIN;
+		returnUrl.pathname = filename;
+	}
 
 	const deleteUrl = new URL(request.url);
 	deleteUrl.pathname = `/delete`;
@@ -110,6 +116,9 @@ router.post("/upload", authMiddleware, async (request: Request, env: Env): Promi
 
 // handle file retrieval
 const getFile = async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+	if(env.ONLY_ALLOW_ACCESS_TO_PUBLIC_BUCKET){
+		return notFound("Not Found");
+	}
 	const url = new URL(request.url);
 	const id = url.pathname.slice(6);
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,3 +16,9 @@ command = "npm run build"
 bucket_name = "sharex-files"
 preview_bucket_name = "sharex-files"
 binding = "R2_BUCKET"
+
+[vars]
+# Change to the domain your Public Bucket is connected to.
+#CUSTOM_PUBLIC_BUCKET_DOMAIN = "custom-bucket.domain.tld"
+# Change to not let the worker serve files, only allowing traffic through the Public Bucket. Do not set if you have old links pointing to the worker.
+#ONLY_ALLOW_ACCESS_TO_PUBLIC_BUCKET = true 


### PR DESCRIPTION
Now that Public Buckets are out, it would be cool if this worker supported using them by returning the URL with the public bucket domain and optionally disabling serving any files from the worker. Saving on Workers Invocations and potential speed improvements. No worries if you don't think it is necessary!

Side Note: Worker Custom Domains are now GA too, might be easier for people to set up if the project used them by default.