### PR TITLE
Delete requests from cache when deleting from R2

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -142,8 +142,11 @@ router.get("/delete", authMiddleware, async (request: Request, env: Env): Promis
 		return notFound('Missing filename');
 	}
 
-	// write to R2
+	// delete from R2
 	try{
+		const cache = caches.default;
+		await cache.delete(new Request(`https://r2host/${filename}`, request));
+
 		await env.R2_BUCKET.delete(filename);
 		return new Response(JSON.stringify({
 			success: true,


### PR DESCRIPTION
When you delete a file from R2, the request is still available in cache. This PR makes it so that requests are deleted from cache on a delete request.